### PR TITLE
Add Next.js todo list skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Todo List App
+
+This is a simple todo list application built with Next.js and Tailwind CSS. It supports
+creating daily memos and tasks with progress tracking. Data is currently stored in
+`localStorage`, but a `supabaseClient` is provided for future integration with Supabase.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/components/TodoForm.js
+++ b/components/TodoForm.js
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+
+export default function TodoForm({ onAdd }) {
+  const [title, setTitle] = useState('')
+  const [category, setCategory] = useState('General')
+  const [date, setDate] = useState('')
+  const [memo, setMemo] = useState('')
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    if (!title) return
+    onAdd({
+      title,
+      category,
+      date,
+      progress: 0,
+      memo,
+    })
+    setTitle('')
+    setDate('')
+    setMemo('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        className="border p-2 w-full"
+        placeholder="Task title"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+      />
+      <input
+        className="border p-2 w-full"
+        placeholder="Category"
+        value={category}
+        onChange={e => setCategory(e.target.value)}
+      />
+      <input
+        type="date"
+        className="border p-2 w-full"
+        value={date}
+        onChange={e => setDate(e.target.value)}
+      />
+      <textarea
+        className="border p-2 w-full"
+        placeholder="Memo"
+        value={memo}
+        onChange={e => setMemo(e.target.value)}
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Add Task
+      </button>
+    </form>
+  )
+}

--- a/components/TodoList.js
+++ b/components/TodoList.js
@@ -1,0 +1,32 @@
+export default function TodoList({ todos, onUpdate }) {
+  const handleProgress = (id, progress) => {
+    onUpdate(id, progress);
+  };
+
+  const grouped = todos.reduce((acc, todo) => {
+    acc[todo.category] = acc[todo.category] || [];
+    acc[todo.category].push(todo);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-4">
+      {Object.keys(grouped).map((category) => (
+        <div key={category} className="border p-4">
+          <h2 className="font-bold mb-2">{category}</h2>
+          {grouped[category].map((todo) => (
+            <div key={todo.id} className="mb-2">
+              <div className="flex justify-between">
+                <span>{todo.title}</span>
+                <span>{todo.date}</span>
+              </div>
+              <progress className="w-full" value={todo.progress} max="100" />
+              <textarea className="border p-1 w-full mt-1" value={todo.memo} readOnly />
+              <input type="range" min="0" max="100" value={todo.progress} onChange={(e) => handleProgress(todo.id, Number(e.target.value))} />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl || '', supabaseAnonKey || '')

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "todolist-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.23",
+    "autoprefixer": "^10.4.13",
+    "@supabase/supabase-js": "^2.0.0"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '@/styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ name: 'John Doe' })
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import TodoForm from '@/components/TodoForm'
+import TodoList from '@/components/TodoList'
+
+export default function Home() {
+  const [todos, setTodos] = useState([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('todos')
+    if (stored) setTodos(JSON.parse(stored))
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('todos', JSON.stringify(todos))
+  }, [todos])
+
+  const addTodo = todo => {
+    setTodos([...todos, { ...todo, id: Date.now() }])
+  }
+
+  const updateProgress = (id, progress) => {
+    setTodos(todos.map(t => (t.id === id ? { ...t, progress } : t)))
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Todo List</h1>
+      <TodoForm onAdd={addTodo} />
+      <TodoList todos={todos} onUpdate={updateProgress} />
+    </div>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,29 @@
+# Todo List Product Requirements
+
+## Overview
+- Allow users to create daily memos and tasks.
+- Each task belongs to a category and includes a due date and progress percentage.
+- Store data locally using `localStorage` for now, with a Supabase client configured for future use.
+
+## Features
+1. **Task Creation**
+   - Title, category, due date, memo field.
+2. **Progress Tracking**
+   - Tasks display a progress bar and can be updated with a range input.
+3. **Category Grouping**
+   - Tasks are grouped by category for easy browsing.
+4. **Daily Memo**
+   - Optional notes attached to each task.
+
+## Tech Stack
+- Next.js
+- Tailwind CSS
+- Supabase (configuration only)
+
+## Folder Structure
+```
+components/       React components
+lib/              Supabase client setup
+pages/            Next.js pages
+styles/           Global styles including Tailwind
+```

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project with Tailwind config
- add Supabase client placeholder
- implement todo list components with localStorage
- document product requirements

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6848cca7e5708331929f3c9fa68db23a