### PR TITLE
Fix bootstrap on client

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,19 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
## Summary
- load Bootstrap from CDN globally using a custom Document
- remove next/head usage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: fetch failed for Next.js binaries)*

------
https://chatgpt.com/codex/tasks/task_e_684917333ee08331b3c9bb1ad3e62bff